### PR TITLE
Fixes a publishing bug

### DIFF
--- a/lib/yandex/disk/client/request/publication.rb
+++ b/lib/yandex/disk/client/request/publication.rb
@@ -36,7 +36,7 @@ class Yandex::Disk::Client::Request::Publication
     end
 
     def characters string
-      @public_url = string if @public_url
+      @public_url = string if (@public_url == true)
     end
   end
 


### PR DESCRIPTION
Here's a bug found. Your code did not work as wanted. The call 
`disk.make_public('/path/to/remote/dir/or/file')`
Returned
`{:public_url=>"HTTP/1.1 200 OK"}`
Instead of the documented
`{:public_url=>"https://yadi.sk/i/B98Qjxxx3S5QJ"}`
Now it works correctly.