### PR TITLE
Fixes a nokogiri version complaint

### DIFF
--- a/lib/yandex/disk/client/request/publication.rb
+++ b/lib/yandex/disk/client/request/publication.rb
@@ -36,7 +36,7 @@ class Yandex::Disk::Client::Request::Publication
     end
 
     def characters string
-      @public_url = string if @public_url
+      @public_url = string if (@public_url == true)
     end
   end
 

--- a/yandex-disk.gemspec
+++ b/yandex-disk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('faraday', '~> 0.8')
-  spec.add_dependency('nokogiri', '~> 1.6.0')
+  spec.add_dependency('nokogiri', '>= 1.6.0')
   spec.add_dependency('faraday_middleware', '~> 0.9.0')
   spec.add_dependency('excon', '>= 0.16')
 


### PR DESCRIPTION
You shouldn't fix the nokogiri version in the gemspec. Otherwise it causes complaints while bundling your gem - with every new fresh nokogiri version.