### PR TITLE
Support storage cycling with new Backup API

### DIFF
--- a/lib/yandex/disk/backup/storage.rb
+++ b/lib/yandex/disk/backup/storage.rb
@@ -5,6 +5,7 @@ module Backup
   module Storage
     module Yandex
       class Disk < Base
+        include Storage::Cycler
 
         attr_accessor :access_token
 


### PR DESCRIPTION
In new Backup API cycling methods was refactored to external module.
After that change cycling functionality in yandex-disk doesn't work as expected.
This commit fixes issue #6 