### PR TITLE
fix strict encode

### DIFF
--- a/lib/yandex/disk/client.rb
+++ b/lib/yandex/disk/client.rb
@@ -18,7 +18,7 @@ module Yandex
           if options[:access_token] && options[:access_token].length > 0
             builder.request :authorization, "OAuth", options[:access_token]
           elsif options[:login] && options[:password]
-            basic_token = Base64.encode64("#{options[:login]}:#{options[:password]}")
+            basic_token = Base64.strict_encode64("#{options[:login]}:#{options[:password]}")
             builder.request :authorization, "Basic", basic_token
           else
             raise ArgumentError, 'No :access_token or :login and :password'

--- a/lib/yandex/disk/client/request/list.rb
+++ b/lib/yandex/disk/client/request/list.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'date'
 
 class Yandex::Disk::Client::Request::List
   HEADERS = {


### PR DESCRIPTION
Изменил при создании токена кодировку Base65 на strict_encode64, т.к. запрос падал с ошибкой Excon::Error::InvalidHeaderValue: "Basic dmxhZGVuNDFrMDA6UzQ4MTUxNjIzNDJj\n" contains forbidden "\r" or "\n"
Насколько я понимаю библиотека excon не хотела принимать символ переноса строки в заголовке.  Метод strict_encode64 удаляет перенос строк. 
Также подгрузил date т.к. ругнулся на неизвестную константу DateTime.